### PR TITLE
Added pdb filetype

### DIFF
--- a/grammars/prolog.cson
+++ b/grammars/prolog.cson
@@ -2,6 +2,7 @@
   'pl'
   'plg'
   'prolog'
+  'pdb'
 ]
 'name': 'Prolog'
 'patterns': [


### PR DESCRIPTION
This is really nothing, but vim used that extension not to confuse prolog and perl, and it was boring to manually say which grammar my file were each time I edited some prolog file.
