### PR TITLE
Add prolog test file extension (.plt)

### DIFF
--- a/grammars/prolog.cson
+++ b/grammars/prolog.cson
@@ -2,6 +2,7 @@
   'pl'
   'pl1'
   'plg'
+  'plt'
   'prolog'
   'pdb'
 ]


### PR DESCRIPTION
Prolog test files have a plt file extension but contain pure prolog and thus should be included in the `fileTypes`.
